### PR TITLE
#CSS:针对 Tag&Archives and Paginator 显示错误的解决

### DIFF
--- a/layout/archive.pug
+++ b/layout/archive.pug
@@ -44,8 +44,9 @@ block content
       h1= page.month + '/' + page.year
 
       - page.posts.each(function(article){
-        .archive-list-item
-          a(href=url_for(article.path))= article.title
+        .post-item
+          p
+            a(href=url_for(article.path))= article.title
           time(datetime=date_xml(article.date))= date(article.date)
       - })
 

--- a/source/css/oasis.styl
+++ b/source/css/oasis.styl
@@ -51,7 +51,9 @@ div#content-outer
         color color-accent
         margin-right 1em
 
-div.post-item
+.post-item
+  width 640px
+  text-align inherit
   margin-bottom: 1em
   p
     margin-top 0

--- a/source/css/oasis.styl
+++ b/source/css/oasis.styl
@@ -39,6 +39,22 @@ nav#menu-inner
     color color-accent
     text-decoration underline
 
+div#paginator
+  width 640px
+  color #718096
+  text-decoration: none;
+  margin-top: 4em
+  .page-number
+    margin-right 1em
+    color #718096
+  .content-inner a
+    color #718096
+  .prev
+    margin-right 1em
+    color #718096
+  .next
+    color #718096
+
 div#content-outer
   margin-top 2em
   div#content-inner


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/57232813/193230279-c9fe7684-e269-461c-af08-92f7c8abc7d9.png)

在 Tag 中，也就是每个文章 Tag 部分，由于部分内容未在 `id="content"` 内容的包裹下而单独进行了一个 `div` 的渲染，导致了原有 `div.post-item` 的样式失效，因此我在不碰坏原有 pug.js（我不会）情况下，修改了 CSS 样式，为其支持同样的排列，解决了此类问题。

error: https://qiantao.one/2018/09/03/new-api-in-gradle-3-0-and-support-library-27-1-0/

![77e581ea9c63755c97bbc2a3fa01f75](https://user-images.githubusercontent.com/57232813/193236639-fdc6af15-cd3c-47a5-9b5c-91aff9ed0987.jpg)

同样另一个问题是没有为 `archives` 下的列表赋予文字样式 error: https://qiantao.one/archives/2018/06/

而还有一个不那么明显的问题是，可能分页部分会出现剧中和样式掉落的情况下，此问题在我本地使用 hexo-theme-oasis 时发现：

![a5422e9e0999f02e33e99f7e7204fe6](https://user-images.githubusercontent.com/57232813/193244434-e29135a9-34f8-45db-a6f4-663742afc995.png)
